### PR TITLE
feat: 응답 데이터 규격 세팅

### DIFF
--- a/src/main/java/com/api/onboardingkit/global/response/ResponseTestController.java
+++ b/src/main/java/com/api/onboardingkit/global/response/ResponseTestController.java
@@ -1,0 +1,20 @@
+package com.api.onboardingkit.global.response;
+
+import com.api.onboardingkit.global.response.dto.Response;
+import com.api.onboardingkit.global.response.dto.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ResponseTestController {
+    private final ResponseTestService responseTestService;
+
+    @GetMapping("/res/test")
+    public Response<String> getTest(@RequestParam boolean throwError) {
+        String data = responseTestService.getTestData(throwError);
+        return Response.success(data, SuccessStatus.TEST_SUCCESS_CODE);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/global/response/ResponseTestService.java
+++ b/src/main/java/com/api/onboardingkit/global/response/ResponseTestService.java
@@ -1,0 +1,15 @@
+package com.api.onboardingkit.global.response;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ResponseTestService {
+    public String getTestData(boolean shouldThrowError) {
+        if (shouldThrowError) {
+            throw new CustomException(ErrorCode.TEST_ERROR_CODE);
+        }
+        return "Test data";
+    }
+}

--- a/src/main/java/com/api/onboardingkit/global/response/dto/ResonDto.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/ResonDto.java
@@ -1,0 +1,13 @@
+package com.api.onboardingkit.global.response.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResonDto {
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/api/onboardingkit/global/response/dto/Response.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/Response.java
@@ -1,0 +1,28 @@
+package com.api.onboardingkit.global.response.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Response<T> {
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T result;
+
+    public static <T> Response<T> success(T result, SuccessStatus status) {
+        return new Response<>(true, status.getCode(), status.getMessage(), result);
+    }
+
+    public static Response<Void> success(SuccessStatus status) {
+        return new Response<>(true, status.getCode(), status.getMessage(), null);
+    }
+
+    public static Response<Void> failure(String code, String message) {
+        return new Response<>(false, code, message, null);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
@@ -1,0 +1,13 @@
+package com.api.onboardingkit.global.response.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus {
+    TEST_SUCCESS_CODE("200", "응답 테스트 성공입니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/api/onboardingkit/global/response/exception/CustomException.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.api.onboardingkit.global.response.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode=errorCode;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.api.onboardingkit.global.response.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    TEST_ERROR_CODE("400", "응답 테스트 실패입니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ExceptionHandlerAdvice.java
@@ -1,0 +1,23 @@
+package com.api.onboardingkit.global.response.exception;
+
+import com.api.onboardingkit.global.response.dto.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionHandlerAdvice {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<Response<Void>> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(Integer.parseInt(e.getErrorCode().getCode()))
+                .body(Response.failure(e.getErrorCode().getCode(), e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Response<Void>> handleGeneralException(Exception e) {
+        return ResponseEntity
+                .status(500)
+                .body(Response.failure("500", e.getMessage()));
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈
> 

## :memo: 작업 내용

> 각 api마다 응답 데이터 규격을 통일하도록 세팅

### 스크린샷 (선택)
<img width="754" alt="스크린샷 2025-03-13 오후 5 44 46" src="https://github.com/user-attachments/assets/98a12975-58cb-403e-9be2-d933741ab454" />
<img width="757" alt="스크린샷 2025-03-13 오후 5 45 13" src="https://github.com/user-attachments/assets/48fcc2e2-e41a-40fb-88ed-e7a83f30c10a" />

## :speech_balloon: 리뷰 요구사항(선택)

> 사용에 어려움이 있다면 말씀해주세요...!
