### PR TITLE
feat: social login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation("io.github.cdimascio:java-dotenv:5.2.2")
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
@@ -1,0 +1,73 @@
+package com.api.onboardingkit.config;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import io.github.cdimascio.dotenv.Dotenv;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Getter
+public class JwtTokenProvider {
+    private String secret;
+    private Key key;
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; //30분
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    @PostConstruct
+    public void init() {
+        Dotenv dotenv = Dotenv.load();
+        this.secret = dotenv.get("JWT_SECRET_KEY");
+        if(this.secret == null || secret.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_JWT_SECRET);
+        }
+
+        this.key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+    }
+
+    public String generateToken(String userId) {
+        return createToken(userId, ACCESS_TOKEN_EXPIRATION);
+    }
+
+    public String generateRefreshToken(String userId) {
+        return createToken(userId, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    private String createToken(String userId, long expiration) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis()+expiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private boolean validateToken(String token) {
+        try{
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.TOKEN_VALIDATE_FAILED);
+        }
+    }
+
+    public String getUserIdFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody().getSubject();
+    }
+
+}

--- a/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,7 +21,7 @@ import io.jsonwebtoken.security.Keys;
 @Configuration
 @ConfigurationProperties(prefix = "jwt")
 @Getter
-@Getter
+@Setter
 public class JwtTokenProvider {
     private String secret;
     private Key key;

--- a/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
@@ -6,7 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SuccessStatus {
-    TEST_SUCCESS_CODE("200", "응답 테스트 성공입니다.");
+    TEST_SUCCESS_CODE("200", "응답 테스트 성공입니다."),
+
+    //oauth
+    OAUTH_AUTHENTICATION("200", "OAuthService authebtication 성공"),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     TOKEN_VALIDATE_FAILED("400","Jwt Token이 유효하지 않습니다."),
     APPLE_ID_VALIDATE_FAILED("400","Apple ID 토큰이 유효하지 않습니다."),
     NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
+    KAKAO_ID_VALIDATE_FAILED("400","Kakao 액세스 토큰이 유효하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     APPLE_ID_VALIDATE_FAILED("400","Apple ID 토큰이 유효하지 않습니다."),
     NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
     KAKAO_ID_VALIDATE_FAILED("400","Kakao 액세스 토큰이 유효하지 않습니다."),
+    GOOGLE_ID_VALIDATE_FAILED("400","Google 액세스 토큰이 유효하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -6,7 +6,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    TEST_ERROR_CODE("400", "응답 테스트 실패입니다.");
+    TEST_ERROR_CODE("400", "응답 테스트 실패입니다."),
+
+    //oauth
+    NOT_ALLOWED_OAUTH_PROVIDER("405", "지원하지 않는 OAuth Provider 입니다."),
+    NOT_FOUND_JWT_SECRET("404","Jwt Secret 키를 찾을 수 없습니다."),
+    TOKEN_VALIDATE_FAILED("400","Jwt Token이 유효하지 않습니다."),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     NOT_ALLOWED_OAUTH_PROVIDER("405", "지원하지 않는 OAuth Provider 입니다."),
     NOT_FOUND_JWT_SECRET("404","Jwt Secret 키를 찾을 수 없습니다."),
     TOKEN_VALIDATE_FAILED("400","Jwt Token이 유효하지 않습니다."),
+    APPLE_ID_VALIDATE_FAILED("400","Apple ID 토큰이 유효하지 않습니다."),
+    NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/member/entity/Member.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/Member.java
@@ -1,0 +1,30 @@
+package com.api.onboardingkit.member.entity;
+
+import jakarta.persistence.*;
+
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;  // 소셜 로그인 이메일
+    private String name;   // 소셜 로그인 사용자 이름
+    private String nickname; // 닉네임
+    private String role;  // 직무 (백엔드, 프론트엔드, 디자이너 등)
+    private String detailRole;  // 상세 직무
+    private int experience; // 연차
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)") // ENUM 대신 문자열 저장
+    private SocialType socialType; // GOOGLE, KAKAO, APPLE
+
+    private String socialId; // 소셜 로그인 ID
+
+    public void updateProfile(String nickname, String role, String detailRole, int experience) {
+        this.nickname = nickname;
+        this.role = role;
+        this.detailRole = detailRole;
+        this.experience = experience;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/member/entity/SocialType.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/SocialType.java
@@ -1,0 +1,5 @@
+package com.api.onboardingkit.member.entity;
+
+public enum SocialType {
+    GOOGLE, KAKAO, APPLE
+}

--- a/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.api.onboardingkit.member.repository;
+
+import com.api.onboardingkit.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
@@ -1,0 +1,24 @@
+package com.api.onboardingkit.oauth.controller;
+
+import com.api.onboardingkit.global.response.dto.Response;
+import com.api.onboardingkit.oauth.dto.OAuthRequestDto;
+import com.api.onboardingkit.oauth.dto.OAuthResponseDto;
+import com.api.onboardingkit.oauth.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/login")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @PostMapping
+    public Response<OAuthResponseDto> login(@RequestBody OAuthRequestDto requestDto) {
+        return oAuthService.authenticate(requestDto);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/dto/OAuthRequestDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/OAuthRequestDto.java
@@ -1,0 +1,9 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthRequestDto {
+    private String provider; // google, kakao, apple
+    private String token; // 앱에서 받은 소셜 로그인 액세스 토큰
+}

--- a/src/main/java/com/api/onboardingkit/oauth/dto/OAuthResponseDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/OAuthResponseDto.java
@@ -1,0 +1,15 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType = "Bearer";
+
+    public OAuthResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
@@ -1,0 +1,86 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Component
+public class AppleOAuthProvider implements OAuthProvider {
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/oauth2/v2/keys";
+
+    @Override
+    public String validateToken(String token) {
+        try{
+            // Apple의 공개 키 가져오기
+            PublicKey publicKey = getApplePublicKey(token);
+
+            // JWT 검증
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            // Apple의 sub 값(사용자 ID) 반환
+            return claims.getSubject();
+        }catch (Exception e){
+            throw new CustomException(ErrorCode.APPLE_ID_VALIDATE_FAILED);
+        }
+    }
+
+    private PublicKey getApplePublicKey(String token) throws Exception {
+        // 토큰 서명에 사용된 Apple의 공개 키를 가져오기
+        // https://developer.apple.com/documentation/accountorganizationaldatasharing/fetch-apple's-public-key-for-verifying-token-signature
+
+        // Apple의 공개 키 목록 가져오기
+        // https://developer.apple.com/documentation/accountorganizationaldatasharing/jwkset/jwkset.keys
+        RestTemplate restTemplate = new RestTemplate();
+        String res = restTemplate.getForObject(APPLE_PUBLIC_KEYS_URL, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode keys = objectMapper.readTree(res).get("keys");
+
+        // JWT Header에서 kid, alg 값 가져오기
+        String[] jwtParts = token.split("\\.");
+        String headerJson = new String(Base64.getUrlDecoder().decode(jwtParts[0]), StandardCharsets.UTF_8);
+        JsonNode header = objectMapper.readTree(headerJson);
+
+        String kid = header.get("kid").asText();
+        String alg = header.get("alg").asText();
+
+        // kid, alg과 일치하는 공개 키 찾기
+        for(JsonNode key : keys){
+            if(key.get("kid").asText().equals(kid) && key.get("alg").asText().equals(alg)){
+                return generatePublicKey(
+                        key.get("n").asText(), // RSA 공개 키의 모듈러스 값
+                        key.get("e").asText() // RSA 공개 키의 지수 값
+                );
+            }
+        }
+        throw new CustomException(ErrorCode.NOT_FOUND_APPLE_PUBLIC_KEY);
+    }
+
+    private PublicKey generatePublicKey(String modulusBase64, String exponentBase64) throws CustomException, NoSuchAlgorithmException, InvalidKeySpecException {
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(modulusBase64));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(exponentBase64));
+
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(modulus, exponent);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePublic(keySpec);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/GoogleOAuthProvider.java
@@ -1,0 +1,27 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class GoogleOAuthProvider implements OAuthProvider {
+    private static final String GOOGLE_TOKEN_INFO_URL = "https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=";
+
+    @Override
+    public String validateToken(String token) {
+        String url = GOOGLE_TOKEN_INFO_URL + token;
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+
+        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+            return response.getBody().get("sub").toString(); // Google 사용자 ID 반환
+        }
+        throw new CustomException(ErrorCode.GOOGLE_ID_VALIDATE_FAILED);
+    }
+
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
@@ -1,0 +1,31 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class KakaoOAuthProvider implements OAuthProvider {
+    private static final String KAKAO_OAUTH_URL = "https://kapi.kakao.com/v2/user/me";
+
+    @Override
+    public String validateToken(String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> res = restTemplate.postForEntity(KAKAO_OAUTH_URL, entity, Map.class);
+
+        if (res.getStatusCode().is2xxSuccessful() && res.getBody() != null) {
+            return res.getBody().get("id").toString(); // Kakao 사용자 ID 반환
+        }
+        throw new CustomException(ErrorCode.KAKAO_ID_VALIDATE_FAILED);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.api.onboardingkit.oauth.provider;
+
+public interface OAuthProvider {
+    String validateToken(String token);
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProviderFactory.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProviderFactory.java
@@ -1,0 +1,27 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class OAuthProviderFactory {
+    private final Map<String, OAuthProvider> providers;
+
+    public OAuthProviderFactory(GoogleOAuthProvider google, KakaoOAuthProvider kakao, AppleOAuthProvider apple) {
+        this.providers = Map.of(
+                "google", google,
+                "kakao", kakao,
+                "apple", apple
+        );
+    }
+
+    public OAuthProvider getProvider(String provider) {
+        if(!providers.containsKey(provider)) {
+            throw new CustomException(ErrorCode.TEST_ERROR_CODE);
+        }
+        return providers.get(provider);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
+++ b/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
@@ -20,7 +20,7 @@ public class OAuthService {
         // 요청받은 OAuth Provider 추출
         OAuthProvider provider = oAuthProviderFactory.getProvider(oAuthRequestDto.getProvider());
 
-        // Access Token 검증 및 사용자 ID 반환
+        // 소셜 계정의 Access Token 검증 및 사용자 ID 반환
         String socialUserId = provider.validateToken(oAuthRequestDto.getToken());
 
         // 응답할 JWT 토큰 발급

--- a/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
+++ b/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
@@ -1,0 +1,35 @@
+package com.api.onboardingkit.oauth.service;
+
+import com.api.onboardingkit.config.JwtTokenProvider;
+import com.api.onboardingkit.global.response.dto.Response;
+import com.api.onboardingkit.global.response.dto.SuccessStatus;
+import com.api.onboardingkit.oauth.dto.OAuthRequestDto;
+import com.api.onboardingkit.oauth.dto.OAuthResponseDto;
+import com.api.onboardingkit.oauth.provider.OAuthProvider;
+import com.api.onboardingkit.oauth.provider.OAuthProviderFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+    private final OAuthProviderFactory oAuthProviderFactory;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Response<OAuthResponseDto> authenticate(OAuthRequestDto oAuthRequestDto) {
+        // 요청받은 OAuth Provider 추출
+        OAuthProvider provider = oAuthProviderFactory.getProvider(oAuthRequestDto.getProvider());
+
+        // Access Token 검증 및 사용자 ID 반환
+        String socialUserId = provider.validateToken(oAuthRequestDto.getToken());
+
+        // 응답할 JWT 토큰 발급
+        String accessToken = jwtTokenProvider.generateToken(socialUserId);
+        String refreshToken = jwtTokenProvider.generateToken(socialUserId);
+
+        return Response.success(
+                new OAuthResponseDto(accessToken, refreshToken),
+                SuccessStatus.OAUTH_AUTHENTICATION
+        );
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈

> #3 소셜 로그인 기능

## :memo: 작업 내용

> 프론트에서 apple, kakao, google 로그인 성공 후 토큰을 발급받고, 이를 서버에서 검증하여 필요한 정보를 추출하도록 구현했다.
### apple 로그인
- apple 서버에서 공개 키 목록을 가져와 해당 토큰 서명에 사용된 키를 추출하여 claim을 파싱
- sub 값으로 사용자 식별, 로그인 처리에 사용

### kakao, google 로그인
- 각 소셜 서버에게 토큰 검증을 요청해서 유효하다면 사용자 ID를 추출하여 반환
- 실패 시 예외 발생

### 스크린샷 (선택)

## :speech_balloon: 리뷰 요구사항(선택)

