### PR TITLE
Feature/3 social login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### env ###
+src/main/resources/.env*

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-    implementation("io.github.cdimascio:java-dotenv:5.2.2")
-
+    implementation "io.github.cdimascio:java-dotenv:5.2.2"
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation("io.github.cdimascio:java-dotenv:5.2.2")
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/api/onboardingkit/article/service/ArticleService.java
+++ b/src/main/java/com/api/onboardingkit/article/service/ArticleService.java
@@ -80,6 +80,28 @@ public class ArticleService {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 아티클이 존재하지 않습니다: " + articleId));
 
+        // 해시태그 개수 세기
+        List<Hashtag> existingHashtags = hashtagRepository.findByArticleId(articleId);
+        int hashtagCount = existingHashtags.size();
+
+        // 해시태그 개수 3개로 제한
+        if (hashtagCount >= 3) {
+            throw new IllegalArgumentException("해시태그는 최대 3개까지만 추가할 수 있습니다.");
+        }
+
+        // 해시태그 개수(등록할 해시태그 1개 포함)에 따른 최대 길이 설정
+        int maxLength = switch (hashtagCount + 1) {
+            case 2 -> 18;
+            case 3 -> 15;
+            case 1 -> 20;
+            default -> 20;
+        };
+
+        // 공백 포함 글자수 최대 길이에 맞춤
+        if (hashtagContent.length() > maxLength) {
+            hashtagContent = hashtagContent.substring(0, maxLength);
+        }
+
         Hashtag hashtag = Hashtag.builder()
                 .articleId(article.getId())
                 .content(hashtagContent)

--- a/src/main/java/com/api/onboardingkit/config/AbstractService.java
+++ b/src/main/java/com/api/onboardingkit/config/AbstractService.java
@@ -2,7 +2,15 @@ package com.api.onboardingkit.config;
 
 public abstract class AbstractService {
 
+    protected String getSocialId() {
+        return SecurityUtil.getCurrentSocialId();
+    }
+
+    protected String getSocialType(){
+        return SecurityUtil.getCurrentSocialType();
+    }
+
     protected Long getUserNo() {
-        return SecurityUtil.getCurrentUserNo();
+        return Long.parseLong(SecurityUtil.getCurrentSocialId());
     }
 }

--- a/src/main/java/com/api/onboardingkit/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.api.onboardingkit.config;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        // 토큰 유효성 검사, claim 추출
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Claims claims = jwtTokenProvider.parseClaims(token);
+
+            // 사용자 인증 객체 생성
+            String socialId = claims.getSubject();
+            Collection<? extends GrantedAuthority> authorities =
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+            // Authentication 객체 생성 후 등록
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            socialId,         // socialId
+                            claims,           // socialType
+                            authorities       // 권한
+                    );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
@@ -1,0 +1,73 @@
+package com.api.onboardingkit.config;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import io.github.cdimascio.dotenv.Dotenv;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Getter
+public class JwtTokenProvider {
+    private String secret;
+    private Key key;
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; //30분
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    @PostConstruct
+    public void init() {
+        Dotenv dotenv = Dotenv.load();
+        this.secret = dotenv.get("JWT_SECRET_KEY");
+        if(this.secret == null || secret.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_JWT_SECRET);
+        }
+
+        this.key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+    }
+
+    public String generateToken(String userId) {
+        return createToken(userId, ACCESS_TOKEN_EXPIRATION);
+    }
+
+    public String generateRefreshToken(String userId) {
+        return createToken(userId, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    private String createToken(String userId, long expiration) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis()+expiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private boolean validateToken(String token) {
+        try{
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.TOKEN_VALIDATE_FAILED);
+        }
+    }
+
+    public String getUserIdFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody().getSubject();
+    }
+
+}

--- a/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,7 +21,7 @@ import io.jsonwebtoken.security.Keys;
 @Configuration
 @ConfigurationProperties(prefix = "jwt")
 @Getter
-@Getter
+@Setter
 public class JwtTokenProvider {
     private String secret;
     private Key key;

--- a/src/main/java/com/api/onboardingkit/config/SecurityUtil.java
+++ b/src/main/java/com/api/onboardingkit/config/SecurityUtil.java
@@ -1,5 +1,6 @@
 package com.api.onboardingkit.config;
 
+import io.jsonwebtoken.Claims;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -8,19 +9,39 @@ public class SecurityUtil {
     /**
      * 현재 로그인한 사용자의 user_no 가져오기
      */
-    public static Long getCurrentUserNo() {
-        // todo. 테스트를 위해 user_no를 하드코딩
-        return 12345L;
-    }
+//    public static Long getCurrentMemberId() {
+//        // todo. 테스트를 위해 user_no를 하드코딩
+//        return 12345L;
+//    }
 
-    /* 현재 로그인한 사용자의 user_no 가져오기
-    public static Long getCurrentUserNo() {
+    //현재 로그인한 사용자의 user_no 가져오기
+//    public static Long getCurrentSocialId() {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+//            throw new IllegalStateException("로그인이 필요합니다.");
+//        }
+//        return Long.parseLong(authentication.getName()); // todo. JWT에서 user_no를 String 형태로 저장한다고 가정
+//    }
+
+    public static String getCurrentSocialId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
         if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        return Long.parseLong(authentication.getName()); // todo. JWT에서 user_no를 String 형태로 저장한다고 가정
+
+        return authentication.getName(); // 여기서는 sub (socialId) 값
     }
-    */
+
+    public static String getCurrentSocialType() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalStateException("로그인이 필요합니다.");
+        }
+
+        Claims claims = (Claims) authentication.getCredentials(); // JWT claims 전체
+        return claims.get("socialType", String.class); // ex: "kakao", "google"
+    }
 
 }

--- a/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
@@ -6,7 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SuccessStatus {
-    TEST_SUCCESS_CODE("200", "응답 테스트 성공입니다.");
+    TEST_SUCCESS_CODE("200", "응답 테스트 성공입니다."),
+
+    //oauth
+    OAUTH_AUTHENTICATION("200", "OAuthService authebtication 성공"),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
@@ -10,6 +10,9 @@ public enum SuccessStatus {
 
     //oauth
     OAUTH_AUTHENTICATION("200", "OAuthService authebtication 성공"),
+
+    //member
+    GET_MEMBER_BY_EMAIL("200","이메일로 멤버 객체 추출 성공"),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/global/response/dto/SuccessStatus.java
@@ -9,10 +9,11 @@ public enum SuccessStatus {
     TEST_SUCCESS_CODE("200", "응답 테스트 성공입니다."),
 
     //oauth
-    OAUTH_AUTHENTICATION("200", "OAuthService authebtication 성공"),
+    OAUTH_AUTHENTICATION("200", "소셜 액세스 토큰 인증 성공"),
 
     //member
     GET_MEMBER_BY_EMAIL("200","이메일로 멤버 객체 추출 성공"),
+    UPDATE_MEMBER_OK("200","회원 정보가 등록되었습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
     KAKAO_ID_VALIDATE_FAILED("400","Kakao 액세스 토큰이 유효하지 않습니다."),
     GOOGLE_ID_VALIDATE_FAILED("400","Google 액세스 토큰이 유효하지 않습니다."),
+
+    //member
+    MEMBER_NOT_FOUND("404","해당 이메일의 멤버를 찾을 수 없습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode {
     GOOGLE_ID_VALIDATE_FAILED("400","Google 액세스 토큰이 유효하지 않습니다."),
 
     //member
-    MEMBER_NOT_FOUND("404","해당 이메일의 멤버를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND_FROM_EMAIL("404","해당 이메일의 멤버를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND_FROM_ACCESS_TOKEN("404","해당 액세스 토큰으로 멤버를 찾을 수 없습니다."),
+
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     TOKEN_VALIDATE_FAILED("400","Jwt Token이 유효하지 않습니다."),
     APPLE_ID_VALIDATE_FAILED("400","Apple ID 토큰이 유효하지 않습니다."),
     NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
+    KAKAO_ID_VALIDATE_FAILED("400","Kakao 액세스 토큰이 유효하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     APPLE_ID_VALIDATE_FAILED("400","Apple ID 토큰이 유효하지 않습니다."),
     NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
     KAKAO_ID_VALIDATE_FAILED("400","Kakao 액세스 토큰이 유효하지 않습니다."),
+    GOOGLE_ID_VALIDATE_FAILED("400","Google 액세스 토큰이 유효하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -6,7 +6,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    TEST_ERROR_CODE("400", "응답 테스트 실패입니다.");
+    TEST_ERROR_CODE("400", "응답 테스트 실패입니다."),
+
+    //oauth
+    NOT_ALLOWED_OAUTH_PROVIDER("405", "지원하지 않는 OAuth Provider 입니다."),
+    NOT_FOUND_JWT_SECRET("404","Jwt Secret 키를 찾을 수 없습니다."),
+    TOKEN_VALIDATE_FAILED("400","Jwt Token이 유효하지 않습니다."),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/global/response/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     NOT_ALLOWED_OAUTH_PROVIDER("405", "지원하지 않는 OAuth Provider 입니다."),
     NOT_FOUND_JWT_SECRET("404","Jwt Secret 키를 찾을 수 없습니다."),
     TOKEN_VALIDATE_FAILED("400","Jwt Token이 유효하지 않습니다."),
+    APPLE_ID_VALIDATE_FAILED("400","Apple ID 토큰이 유효하지 않습니다."),
+    NOT_FOUND_APPLE_PUBLIC_KEY("404","Apple Public Key를 찾을 수 없습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
+++ b/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.api.onboardingkit.member.controller;
+
+import ch.qos.logback.core.status.ErrorStatus;
+import com.api.onboardingkit.global.response.dto.Response;
+import com.api.onboardingkit.global.response.dto.SuccessStatus;
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.api.onboardingkit.member.entity.Member;
+import com.api.onboardingkit.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/member/me/{email}")
+    public Response<?> getMemberByEmail(@PathVariable String email) {
+        Member mem = memberService.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        return Response.success(mem, SuccessStatus.GET_MEMBER_BY_EMAIL);
+    }
+
+}

--- a/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
+++ b/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
@@ -1,17 +1,17 @@
 package com.api.onboardingkit.member.controller;
 
 import ch.qos.logback.core.status.ErrorStatus;
+import com.api.onboardingkit.config.SecurityUtil;
 import com.api.onboardingkit.global.response.dto.Response;
 import com.api.onboardingkit.global.response.dto.SuccessStatus;
 import com.api.onboardingkit.global.response.exception.CustomException;
 import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.api.onboardingkit.member.dto.MemberRequestDto;
 import com.api.onboardingkit.member.entity.Member;
 import com.api.onboardingkit.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -20,10 +20,16 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/member/me/{email}")
-    public Response<?> getMemberByEmail(@PathVariable String email) {
+    public Response<Member> getMemberByEmail(@PathVariable String email) {
         Member mem = memberService.findByEmail(email)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_FROM_EMAIL));
         return Response.success(mem, SuccessStatus.GET_MEMBER_BY_EMAIL);
+    }
+
+    @PatchMapping("/member/me")
+    public Response<?> UpdateMemberInfo(@Valid @RequestBody MemberRequestDto requestDto){
+        memberService.saveOrUpdate(requestDto);
+        return Response.success(SuccessStatus.UPDATE_MEMBER_OK);
     }
 
 }

--- a/src/main/java/com/api/onboardingkit/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/api/onboardingkit/member/dto/MemberRequestDto.java
@@ -1,0 +1,14 @@
+package com.api.onboardingkit.member.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class MemberRequestDto {
+    @Pattern(regexp = "^[가-힣a-zA-Z]{1,8}$", message = "닉네임은 8자 이하로 알파벳과 한글만 조합할 수 있어요.")
+    private String nickname; // 닉네임
+    private String role; // 디자이너, 개발자, 기획자
+    private String detailRole; // 세부 직무
+    @Pattern(regexp = "^[0-9]+$", message = "숫자만 입력해주세요.")
+    private int experience; // 연차
+}

--- a/src/main/java/com/api/onboardingkit/member/entity/Member.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/Member.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@Setter
 @Entity
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/api/onboardingkit/member/entity/Member.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/Member.java
@@ -1,0 +1,30 @@
+package com.api.onboardingkit.member.entity;
+
+import jakarta.persistence.*;
+
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;  // 소셜 로그인 이메일
+    private String name;   // 소셜 로그인 사용자 이름
+    private String nickname; // 닉네임
+    private String role;  // 직무 (백엔드, 프론트엔드, 디자이너 등)
+    private String detailRole;  // 상세 직무
+    private int experience; // 연차
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)") // ENUM 대신 문자열 저장
+    private SocialType socialType; // GOOGLE, KAKAO, APPLE
+
+    private String socialId; // 소셜 로그인 ID
+
+    public void updateProfile(String nickname, String role, String detailRole, int experience) {
+        this.nickname = nickname;
+        this.role = role;
+        this.detailRole = detailRole;
+        this.experience = experience;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/member/entity/Member.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/Member.java
@@ -1,7 +1,14 @@
 package com.api.onboardingkit.member.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
+@Getter
+@Setter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Member {
 
     @Id
@@ -27,4 +34,5 @@ public class Member {
         this.detailRole = detailRole;
         this.experience = experience;
     }
+
 }

--- a/src/main/java/com/api/onboardingkit/member/entity/Member.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/Member.java
@@ -15,6 +15,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = true)
     private String email;  // 소셜 로그인 이메일
     private String name;   // 소셜 로그인 사용자 이름
     private String nickname; // 닉네임

--- a/src/main/java/com/api/onboardingkit/member/entity/SocialType.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/SocialType.java
@@ -1,5 +1,23 @@
 package com.api.onboardingkit.member.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum SocialType {
-    GOOGLE, KAKAO, APPLE
+    GOOGLE("google"),
+    KAKAO("kakao"),
+    APPLE("apple");
+
+    private final String value;
+
+    public static SocialType from(String input) {
+        for (SocialType type : SocialType.values()) {
+            if (type.getValue().equalsIgnoreCase(input)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown social type: " + input);
+    }
 }

--- a/src/main/java/com/api/onboardingkit/member/entity/SocialType.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/SocialType.java
@@ -1,0 +1,5 @@
+package com.api.onboardingkit.member.entity;
+
+public enum SocialType {
+    GOOGLE, KAKAO, APPLE
+}

--- a/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
@@ -1,11 +1,13 @@
 package com.api.onboardingkit.member.repository;
 
 import com.api.onboardingkit.member.entity.Member;
+import com.api.onboardingkit.member.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findById(Long id);
     Optional<Member> findByEmail(String email);
-    Optional<Member> findBySocialIdAndProvider(String socialId, String provider);
+    Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 }

--- a/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findBySocialIdAndProvider(String socialId, String provider);
 }

--- a/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/onboardingkit/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.api.onboardingkit.member.repository;
+
+import com.api.onboardingkit.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/api/onboardingkit/member/service/MemberService.java
+++ b/src/main/java/com/api/onboardingkit/member/service/MemberService.java
@@ -1,6 +1,11 @@
 package com.api.onboardingkit.member.service;
 
+import com.api.onboardingkit.config.AbstractService;
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.api.onboardingkit.member.dto.MemberRequestDto;
 import com.api.onboardingkit.member.entity.Member;
+import com.api.onboardingkit.member.entity.SocialType;
 import com.api.onboardingkit.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -10,20 +15,30 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class MemberService {
+public class MemberService extends AbstractService{
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member saveOrUpdate(Member member) {
-        Optional<Member> optionalMember = memberRepository.findByEmail(member.getEmail());
+    public Member saveOrUpdate(MemberRequestDto requestDto) {
 
-        return optionalMember.map(mem ->{
-            mem.updateProfile(member.getNickname(), member.getRole(), member.getDetailRole(), member.getExperience());
-            return memberRepository.save(mem);
-        }).orElseGet(() -> memberRepository.save(member));
+        // 헤더에서 토큰으로 사용자 정보 추출하여 기능 수행
+        SocialType socialType = SocialType.from(getSocialType());
+        Optional<Member> optionalMember = memberRepository.findBySocialIdAndSocialType(getSocialId(), socialType);
+
+        Member member = optionalMember
+                .map(m -> {
+                    m.updateProfile(
+                            requestDto.getNickname(),
+                            requestDto.getRole(),
+                            requestDto.getDetailRole(),
+                            requestDto.getExperience()
+                    );
+                    return memberRepository.save(m);
+                })
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_FROM_ACCESS_TOKEN));
+
+        return member;
     }
 
     public Optional<Member> findByEmail(String email) {return memberRepository.findByEmail(email);}
-
-
 }

--- a/src/main/java/com/api/onboardingkit/member/service/MemberService.java
+++ b/src/main/java/com/api/onboardingkit/member/service/MemberService.java
@@ -15,13 +15,15 @@ public class MemberService {
 
     @Transactional
     public Member saveOrUpdate(Member member) {
-        Optional<Member> mem = memberRepository.findByEmail(member.getEmail());
+        Optional<Member> optionalMember = memberRepository.findByEmail(member.getEmail());
 
-        return mem.map(m ->{
-            m.updateProfile(member.getNickname(), member.getRole(), member.getDetailRole(), member.getExperience());
-            return memberRepository.save(m);
+        return optionalMember.map(mem ->{
+            mem.updateProfile(member.getNickname(), member.getRole(), member.getDetailRole(), member.getExperience());
+            return memberRepository.save(mem);
         }).orElseGet(() -> memberRepository.save(member));
     }
 
     public Optional<Member> findByEmail(String email) {return memberRepository.findByEmail(email);}
+
+
 }

--- a/src/main/java/com/api/onboardingkit/member/service/MemberService.java
+++ b/src/main/java/com/api/onboardingkit/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package com.api.onboardingkit.member.service;
+
+import com.api.onboardingkit.member.entity.Member;
+import com.api.onboardingkit.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member saveOrUpdate(Member member) {
+        Optional<Member> mem = memberRepository.findByEmail(member.getEmail());
+
+        return mem.map(m ->{
+            m.updateProfile(member.getNickname(), member.getRole(), member.getDetailRole(), member.getExperience());
+            return memberRepository.save(m);
+        }).orElseGet(() -> memberRepository.save(member));
+    }
+
+    public Optional<Member> findByEmail(String email) {return memberRepository.findByEmail(email);}
+}

--- a/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
@@ -11,14 +11,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth/login")
+@RequestMapping("/oauth")
 @RequiredArgsConstructor
 public class OAuthController {
 
     private final OAuthService oAuthService;
 
-    @PostMapping
-    public Response<OAuthResponseDto> login(@RequestBody OAuthRequestDto requestDto) {
+    @PostMapping("/login")
+    public Response<OAuthResponseDto> OAuth2Login(@RequestBody OAuthRequestDto requestDto) {
         return oAuthService.authenticate(requestDto);
     }
 }

--- a/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
@@ -1,0 +1,24 @@
+package com.api.onboardingkit.oauth.controller;
+
+import com.api.onboardingkit.global.response.dto.Response;
+import com.api.onboardingkit.oauth.dto.OAuthRequestDto;
+import com.api.onboardingkit.oauth.dto.OAuthResponseDto;
+import com.api.onboardingkit.oauth.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/login")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @PostMapping
+    public Response<OAuthResponseDto> login(@RequestBody OAuthRequestDto requestDto) {
+        return oAuthService.authenticate(requestDto);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/dto/OAuthRequestDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/OAuthRequestDto.java
@@ -1,0 +1,9 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthRequestDto {
+    private String provider; // google, kakao, apple
+    private String token; // 앱에서 받은 소셜 로그인 액세스 토큰
+}

--- a/src/main/java/com/api/onboardingkit/oauth/dto/OAuthRequestDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/OAuthRequestDto.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class OAuthRequestDto {
-    private String provider; // google, kakao, apple
+    private String socialType; // google, kakao, apple
     private String token; // 앱에서 받은 소셜 로그인 액세스 토큰
 }

--- a/src/main/java/com/api/onboardingkit/oauth/dto/OAuthResponseDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/OAuthResponseDto.java
@@ -1,0 +1,15 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType = "Bearer";
+
+    public OAuthResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/dto/SocialUserInfo.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/SocialUserInfo.java
@@ -1,0 +1,14 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SocialUserInfo {
+    private String socialId;
+    private String email;
+
+    public SocialUserInfo(String socialId, String email) {
+        this.socialId = socialId;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
@@ -3,7 +3,6 @@ package com.api.onboardingkit.oauth.provider;
 import com.api.onboardingkit.global.response.exception.CustomException;
 import com.api.onboardingkit.global.response.exception.ErrorCode;
 import com.api.onboardingkit.oauth.dto.SocialUserInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -20,9 +21,10 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 
+@Slf4j
 @Component
 public class AppleOAuthProvider implements OAuthProvider {
-    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/oauth2/v2/keys";
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
 
     @Override
     public SocialUserInfo validateToken(String token) {
@@ -36,12 +38,14 @@ public class AppleOAuthProvider implements OAuthProvider {
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
-
+            
             // Apple의 sub 값(사용자 ID)과 이메일 반환
             String email = claims.get("email", String.class);
             String id = claims.getSubject();
+
             return new SocialUserInfo(id, email);
         }catch (Exception e){
+            log.error("Apple 토큰 검증 실패: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.APPLE_ID_VALIDATE_FAILED);
         }
     }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
@@ -40,7 +40,8 @@ public class AppleOAuthProvider implements OAuthProvider {
 
             // Apple의 sub 값(사용자 ID)과 이메일 반환
             String email = claims.get("email", String.class);
-            return new SocialUserInfo(claims.getSubject(), email);
+            String id = claims.getSubject();
+            return new SocialUserInfo(id, email);
         }catch (Exception e){
             throw new CustomException(ErrorCode.APPLE_ID_VALIDATE_FAILED);
         }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
@@ -2,6 +2,7 @@ package com.api.onboardingkit.oauth.provider;
 
 import com.api.onboardingkit.global.response.exception.CustomException;
 import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.api.onboardingkit.oauth.dto.SocialUserInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,7 +26,7 @@ public class AppleOAuthProvider implements OAuthProvider {
     private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/oauth2/v2/keys";
 
     @Override
-    public String validateToken(String token) {
+    public SocialUserInfo validateToken(String token) {
         try{
             // Apple의 공개 키 가져오기
             PublicKey publicKey = getApplePublicKey(token);
@@ -36,8 +37,10 @@ public class AppleOAuthProvider implements OAuthProvider {
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
-            // Apple의 sub 값(사용자 ID) 반환
-            return claims.getSubject();
+
+            // Apple의 sub 값(사용자 ID)과 이메일 반환
+            String email = claims.get("email", String.class);
+            return new SocialUserInfo(claims.getSubject(), email);
         }catch (Exception e){
             throw new CustomException(ErrorCode.APPLE_ID_VALIDATE_FAILED);
         }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/AppleOAuthProvider.java
@@ -1,0 +1,86 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Component
+public class AppleOAuthProvider implements OAuthProvider {
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/oauth2/v2/keys";
+
+    @Override
+    public String validateToken(String token) {
+        try{
+            // Apple의 공개 키 가져오기
+            PublicKey publicKey = getApplePublicKey(token);
+
+            // JWT 검증
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            // Apple의 sub 값(사용자 ID) 반환
+            return claims.getSubject();
+        }catch (Exception e){
+            throw new CustomException(ErrorCode.APPLE_ID_VALIDATE_FAILED);
+        }
+    }
+
+    private PublicKey getApplePublicKey(String token) throws Exception {
+        // 토큰 서명에 사용된 Apple의 공개 키를 가져오기
+        // https://developer.apple.com/documentation/accountorganizationaldatasharing/fetch-apple's-public-key-for-verifying-token-signature
+
+        // Apple의 공개 키 목록 가져오기
+        // https://developer.apple.com/documentation/accountorganizationaldatasharing/jwkset/jwkset.keys
+        RestTemplate restTemplate = new RestTemplate();
+        String res = restTemplate.getForObject(APPLE_PUBLIC_KEYS_URL, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode keys = objectMapper.readTree(res).get("keys");
+
+        // JWT Header에서 kid, alg 값 가져오기
+        String[] jwtParts = token.split("\\.");
+        String headerJson = new String(Base64.getUrlDecoder().decode(jwtParts[0]), StandardCharsets.UTF_8);
+        JsonNode header = objectMapper.readTree(headerJson);
+
+        String kid = header.get("kid").asText();
+        String alg = header.get("alg").asText();
+
+        // kid, alg과 일치하는 공개 키 찾기
+        for(JsonNode key : keys){
+            if(key.get("kid").asText().equals(kid) && key.get("alg").asText().equals(alg)){
+                return generatePublicKey(
+                        key.get("n").asText(), // RSA 공개 키의 모듈러스 값
+                        key.get("e").asText() // RSA 공개 키의 지수 값
+                );
+            }
+        }
+        throw new CustomException(ErrorCode.NOT_FOUND_APPLE_PUBLIC_KEY);
+    }
+
+    private PublicKey generatePublicKey(String modulusBase64, String exponentBase64) throws CustomException, NoSuchAlgorithmException, InvalidKeySpecException {
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(modulusBase64));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(exponentBase64));
+
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(modulus, exponent);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePublic(keySpec);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/GoogleOAuthProvider.java
@@ -1,0 +1,27 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class GoogleOAuthProvider implements OAuthProvider {
+    private static final String GOOGLE_TOKEN_INFO_URL = "https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=";
+
+    @Override
+    public String validateToken(String token) {
+        String url = GOOGLE_TOKEN_INFO_URL + token;
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+
+        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+            return response.getBody().get("sub").toString(); // Google 사용자 ID 반환
+        }
+        throw new CustomException(ErrorCode.GOOGLE_ID_VALIDATE_FAILED);
+    }
+
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/GoogleOAuthProvider.java
@@ -2,6 +2,7 @@ package com.api.onboardingkit.oauth.provider;
 
 import com.api.onboardingkit.global.response.exception.CustomException;
 import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.api.onboardingkit.oauth.dto.SocialUserInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -13,13 +14,15 @@ public class GoogleOAuthProvider implements OAuthProvider {
     private static final String GOOGLE_TOKEN_INFO_URL = "https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=";
 
     @Override
-    public String validateToken(String token) {
+    public SocialUserInfo validateToken(String token) {
         String url = GOOGLE_TOKEN_INFO_URL + token;
         RestTemplate restTemplate = new RestTemplate();
         ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
 
         if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            return response.getBody().get("sub").toString(); // Google 사용자 ID 반환
+            String id = response.getBody().get("sub").toString();
+            String email = response.getBody().get("email").toString();
+            return new SocialUserInfo(id, email);
         }
         throw new CustomException(ErrorCode.GOOGLE_ID_VALIDATE_FAILED);
     }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
@@ -2,6 +2,7 @@ package com.api.onboardingkit.oauth.provider;
 
 import com.api.onboardingkit.global.response.exception.CustomException;
 import com.api.onboardingkit.global.response.exception.ErrorCode;
+import com.api.onboardingkit.oauth.dto.SocialUserInfo;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -15,16 +16,19 @@ public class KakaoOAuthProvider implements OAuthProvider {
     private static final String KAKAO_OAUTH_URL = "https://kapi.kakao.com/v2/user/me";
 
     @Override
-    public String validateToken(String token) {
+    public SocialUserInfo validateToken(String token) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(token);
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<Map> res = restTemplate.postForEntity(KAKAO_OAUTH_URL, entity, Map.class);
+        ResponseEntity<Map> response = restTemplate.postForEntity(KAKAO_OAUTH_URL, entity, Map.class);
 
-        if (res.getStatusCode().is2xxSuccessful() && res.getBody() != null) {
-            return res.getBody().get("id").toString(); // Kakao 사용자 ID 반환
+        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+            String email = response.getBody().get("email").toString();
+            String id = response.getBody().get("id").toString();
+
+            return new SocialUserInfo(id, email);
         }
         throw new CustomException(ErrorCode.KAKAO_ID_VALIDATE_FAILED);
     }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
@@ -1,0 +1,31 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class KakaoOAuthProvider implements OAuthProvider {
+    private static final String KAKAO_OAUTH_URL = "https://kapi.kakao.com/v2/user/me";
+
+    @Override
+    public String validateToken(String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> res = restTemplate.postForEntity(KAKAO_OAUTH_URL, entity, Map.class);
+
+        if (res.getStatusCode().is2xxSuccessful() && res.getBody() != null) {
+            return res.getBody().get("id").toString(); // Kakao 사용자 ID 반환
+        }
+        throw new CustomException(ErrorCode.KAKAO_ID_VALIDATE_FAILED);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/KakaoOAuthProvider.java
@@ -25,8 +25,14 @@ public class KakaoOAuthProvider implements OAuthProvider {
         ResponseEntity<Map> response = restTemplate.postForEntity(KAKAO_OAUTH_URL, entity, Map.class);
 
         if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            String email = response.getBody().get("email").toString();
-            String id = response.getBody().get("id").toString();
+            Map<String, Object> body = response.getBody();
+
+            String id = body.get("id").toString();
+            Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+            if (kakaoAccount == null || kakaoAccount.get("email") == null) {
+                throw new CustomException(ErrorCode.KAKAO_ID_VALIDATE_FAILED);
+            }
+            String email = kakaoAccount.get("email").toString();
 
             return new SocialUserInfo(id, email);
         }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.api.onboardingkit.oauth.provider;
+
+public interface OAuthProvider {
+    String validateToken(String token);
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProvider.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProvider.java
@@ -1,5 +1,7 @@
 package com.api.onboardingkit.oauth.provider;
 
+import com.api.onboardingkit.oauth.dto.SocialUserInfo;
+
 public interface OAuthProvider {
-    String validateToken(String token);
+    SocialUserInfo validateToken(String token);
 }

--- a/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProviderFactory.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProviderFactory.java
@@ -1,0 +1,27 @@
+package com.api.onboardingkit.oauth.provider;
+
+import com.api.onboardingkit.global.response.exception.CustomException;
+import com.api.onboardingkit.global.response.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class OAuthProviderFactory {
+    private final Map<String, OAuthProvider> providers;
+
+    public OAuthProviderFactory(GoogleOAuthProvider google, KakaoOAuthProvider kakao, AppleOAuthProvider apple) {
+        this.providers = Map.of(
+                "google", google,
+                "kakao", kakao,
+                "apple", apple
+        );
+    }
+
+    public OAuthProvider getProvider(String provider) {
+        if(!providers.containsKey(provider)) {
+            throw new CustomException(ErrorCode.TEST_ERROR_CODE);
+        }
+        return providers.get(provider);
+    }
+}

--- a/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProviderFactory.java
+++ b/src/main/java/com/api/onboardingkit/oauth/provider/OAuthProviderFactory.java
@@ -20,7 +20,7 @@ public class OAuthProviderFactory {
 
     public OAuthProvider getProvider(String provider) {
         if(!providers.containsKey(provider)) {
-            throw new CustomException(ErrorCode.TEST_ERROR_CODE);
+            throw new CustomException(ErrorCode.NOT_ALLOWED_OAUTH_PROVIDER);
         }
         return providers.get(provider);
     }

--- a/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
+++ b/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
@@ -3,6 +3,9 @@ package com.api.onboardingkit.oauth.service;
 import com.api.onboardingkit.config.JwtTokenProvider;
 import com.api.onboardingkit.global.response.dto.Response;
 import com.api.onboardingkit.global.response.dto.SuccessStatus;
+import com.api.onboardingkit.member.entity.Member;
+import com.api.onboardingkit.member.entity.SocialType;
+import com.api.onboardingkit.member.repository.MemberRepository;
 import com.api.onboardingkit.oauth.dto.OAuthRequestDto;
 import com.api.onboardingkit.oauth.dto.OAuthResponseDto;
 import com.api.onboardingkit.oauth.provider.OAuthProvider;
@@ -10,11 +13,14 @@ import com.api.onboardingkit.oauth.provider.OAuthProviderFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class OAuthService {
     private final OAuthProviderFactory oAuthProviderFactory;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     public Response<OAuthResponseDto> authenticate(OAuthRequestDto oAuthRequestDto) {
         // 요청받은 OAuth Provider 추출
@@ -22,6 +28,16 @@ public class OAuthService {
 
         // 소셜 계정의 Access Token 검증 및 사용자 ID 반환
         String socialUserId = provider.validateToken(oAuthRequestDto.getToken());
+
+        // 사용자 조회 or DB에 저장
+        Member member = memberRepository.findBySocialIdAndProvider(socialUserId, oAuthRequestDto.getProvider())
+                .orElseGet(()-> {
+                    Member newMember = Member.builder()
+                            .socialType(SocialType.valueOf(oAuthRequestDto.getProvider()))
+                            .socialId(socialUserId)
+                            .build();
+                    return memberRepository.save(newMember);
+                });
 
         // 응답할 JWT 토큰 발급
         String accessToken = jwtTokenProvider.generateToken(socialUserId);

--- a/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
+++ b/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
@@ -43,7 +43,7 @@ public class OAuthService {
                 });
 
         // 응답할 JWT 토큰 발급
-        String accessToken = jwtTokenProvider.generateToken(memberInfo.getSocialId(), member.getId());
+        String accessToken = jwtTokenProvider.generateToken(memberInfo.getSocialId(), socialType.getValue());
         String refreshToken = jwtTokenProvider.generateRefreshToken(memberInfo.getSocialId());
 
         return Response.success(

--- a/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
+++ b/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
@@ -20,7 +20,7 @@ public class OAuthService {
         // 요청받은 OAuth Provider 추출
         OAuthProvider provider = oAuthProviderFactory.getProvider(oAuthRequestDto.getProvider());
 
-        // Access Token 검증 및 사용자 ID 반환
+        // 소셜 계정의 Access Token 검증 및 사용자 ID 반환
         String socialUserId = provider.validateToken(oAuthRequestDto.getToken());
 
         // 응답할 JWT 토큰 발급

--- a/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
+++ b/src/main/java/com/api/onboardingkit/oauth/service/OAuthService.java
@@ -1,0 +1,35 @@
+package com.api.onboardingkit.oauth.service;
+
+import com.api.onboardingkit.config.JwtTokenProvider;
+import com.api.onboardingkit.global.response.dto.Response;
+import com.api.onboardingkit.global.response.dto.SuccessStatus;
+import com.api.onboardingkit.oauth.dto.OAuthRequestDto;
+import com.api.onboardingkit.oauth.dto.OAuthResponseDto;
+import com.api.onboardingkit.oauth.provider.OAuthProvider;
+import com.api.onboardingkit.oauth.provider.OAuthProviderFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+    private final OAuthProviderFactory oAuthProviderFactory;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Response<OAuthResponseDto> authenticate(OAuthRequestDto oAuthRequestDto) {
+        // 요청받은 OAuth Provider 추출
+        OAuthProvider provider = oAuthProviderFactory.getProvider(oAuthRequestDto.getProvider());
+
+        // Access Token 검증 및 사용자 ID 반환
+        String socialUserId = provider.validateToken(oAuthRequestDto.getToken());
+
+        // 응답할 JWT 토큰 발급
+        String accessToken = jwtTokenProvider.generateToken(socialUserId);
+        String refreshToken = jwtTokenProvider.generateToken(socialUserId);
+
+        return Response.success(
+                new OAuthResponseDto(accessToken, refreshToken),
+                SuccessStatus.OAUTH_AUTHENTICATION
+        );
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈

> #3 소셜 로그인 기능

## :memo: 작업 내용

> 프론트에서 apple, kakao, google 로그인 성공 후 토큰을 발급받고, 이를 서버에서 검증하여 필요한 정보를 추출하도록 구현했다.

### 1-1. kakao 로그인
- 각 소셜 서버에게 토큰 검증을 요청해서 유효하다면 사용자 ID를 추출하여 반환
- 실패 시 예외 발생

### 1-2. apple 로그인
- apple 서버에서 공개 키 목록을 가져와 해당 토큰 서명에 사용된 키를 추출하여 claim을 파싱
- sub 값으로 사용자 식별, 로그인 처리에 사용

### 2. 소셜 토큰 검증 후 acess token 발급
- `JwtTokenProvider`: sub에 socialId 값을, claim에 socialType 값을 넣어서 jwt 생성
- `JwtAuthenticationFilter`: 토큰 안의 socialId, socialType를 추출해서 인증 객체를 생성, SecurityContext 에 등록

### 3. 토큰으로 사용자 고유번호 추출하기
- `SecurityUtil`: SecurityContext에 저장된 sub(socialId), claim(socialType)를 추출
- 대상 사용자를 socialId+socialType을 가지고 판별

### 4. 사용자 정보 수집
- 닉네임은 8자 이하, 알파벳과 한글 조합으로만 입력 제한
- 직무, 세부직무는 String으로 받음
- 연차는 숫자로만 입력 제한

### 스크린샷
- kakao 로그인
<img width="752" alt="스크린샷 2025-04-10 오후 9 51 36" src="https://github.com/user-attachments/assets/a4b9a841-6fde-473f-b720-4f4fe0e20852" />
<img width="752" alt="스크린샷 2025-04-10 오후 9 51 36" src="https://github.com/user-attachments/assets/ce233790-0f10-4081-8717-67627dbec3f5" />

- apple 로그인
<img width="708" alt="스크린샷 2025-04-12 오후 10 50 06" src="https://github.com/user-attachments/assets/07c39dcd-d430-4182-a245-30a16055b241" />
<img width="708" alt="스크린샷 2025-04-12 오후 10 50 06" src="https://github.com/user-attachments/assets/55771d11-4784-417d-80e2-6a7d9b86e361" />

- 사용자 정보 수집
<img width="752" alt="스크린샷 2025-04-12 오후 10 52 20" src="https://github.com/user-attachments/assets/310c6f58-f6de-4119-8a73-5a883bf873d1" />
<img width="752" alt="스크린샷 2025-04-12 오후 10 52 20" src="https://github.com/user-attachments/assets/c9b7cd8b-3388-49b7-b1d3-4f28e2a37b9c" />

## :speech_balloon: 리뷰 요구사항(선택)
@integerJI AbstractService에 getuserNo 메소드랑 연관된 코드가 있더라구요. userNo가 socialId값으로 기억해서 일단 그렇게 연결시켜놓았습니다. 이름만 다르고 중복된 코드 한 번 싹 정리하면 좋을 것 같아요...! 피드백 부탁드리겠습니다..~
