### PR TITLE
[feat] 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/api/onboardingkit/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtAuthenticationFilter.java
@@ -36,15 +36,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = jwtTokenProvider.parseClaims(token);
 
             // 사용자 인증 객체 생성
-            String socialId = claims.getSubject();
+            String memberId = claims.getSubject();
             Collection<? extends GrantedAuthority> authorities =
                     List.of(new SimpleGrantedAuthority("ROLE_USER"));
 
             // Authentication 객체 생성 후 등록
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
-                            socialId,         // socialId
-                            claims,           // socialType
+                            memberId,
                             authorities       // 권한
                     );
 

--- a/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
+++ b/src/main/java/com/api/onboardingkit/config/JwtTokenProvider.java
@@ -24,7 +24,7 @@ import io.jsonwebtoken.security.Keys;
 public class JwtTokenProvider {
     private String secret;
     private Key key;
-    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; //30분
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 5; // 5시간
     private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
 
     @PostConstruct
@@ -64,14 +64,9 @@ public class JwtTokenProvider {
         }
     }
 
-    public String getSocialIdFromToken(String token) {
+    public String getMemberIdFromToken(String token) {
         Claims claims = parseClaims(token);
-        return claims.getSubject(); // sub, socialId 값
-    }
-
-    public String getSocialTypeFromToken(String token) {
-        Claims claims = parseClaims(token);
-        return claims.get("socialType", String.class); // socialType(provider) 값
+        return claims.getSubject(); // sub, memberId 값
     }
 
     public Claims parseClaims(String token) {

--- a/src/main/java/com/api/onboardingkit/config/exception/ErrorCode.java
+++ b/src/main/java/com/api/onboardingkit/config/exception/ErrorCode.java
@@ -16,10 +16,14 @@ public enum ErrorCode {
     NOT_FOUND_APPLE_PUBLIC_KEY(404,"Apple Public Key를 찾을 수 없습니다."),
     KAKAO_ID_VALIDATE_FAILED(400,"Kakao 액세스 토큰이 유효하지 않습니다."),
     GOOGLE_ID_VALIDATE_FAILED(400,"Google 액세스 토큰이 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(400,"유효하지 않은 refresh 토큰입니다."),
+    REFRESH_TOKEN_MISMATCH(400,"멤버에 저장된 refresh 토큰과 일치하지 않습니다."),
 
     //member
     MEMBER_NOT_FOUND_FROM_EMAIL(404,"해당 이메일의 멤버를 찾을 수 없습니다."),
-    MEMBER_NOT_FOUND_FROM_ACCESS_TOKEN(404,"해당 액세스 토큰으로 멤버를 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND_FROM_ACCESS_TOKEN(404,"해당 액세스 토큰으로 멤버를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(404,"회원 정보를 찾을 수 없습니다."),
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/api/onboardingkit/config/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/config/response/dto/SuccessStatus.java
@@ -14,7 +14,7 @@ public enum SuccessStatus {
     TOKEN_REISSUE_OK(200,"토큰 재발급 성공"),
 
     //member
-    GET_MEMBER_BY_EMAIL(200,"이메일로 멤버 객체 추출 성공"),
+    GET_MEMBER_OK(200,"멤버 조회 성공"),
     UPDATE_MEMBER_OK(200,"회원 정보가 등록되었습니다.");
 
     private final int code;

--- a/src/main/java/com/api/onboardingkit/config/response/dto/SuccessStatus.java
+++ b/src/main/java/com/api/onboardingkit/config/response/dto/SuccessStatus.java
@@ -11,6 +11,7 @@ public enum SuccessStatus {
     SUCCESS(200,"성공"),
     //oauth
     OAUTH_AUTHENTICATION(200, "소셜 액세스 토큰 인증 성공"),
+    TOKEN_REISSUE_OK(200,"토큰 재발급 성공"),
 
     //member
     GET_MEMBER_BY_EMAIL(200,"이메일로 멤버 객체 추출 성공"),

--- a/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
+++ b/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
     public CustomResponse<Member> getMyProfile() {
         Member member = memberService.getCurrentMember()
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_FROM_ACCESS_TOKEN));
-        return CustomResponse.success(member, SuccessStatus.GET_MEMBER_BY_EMAIL);
+        return CustomResponse.success(member, SuccessStatus.GET_MEMBER_OK);
     }
 
     @PatchMapping

--- a/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
+++ b/src/main/java/com/api/onboardingkit/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.api.onboardingkit.member.entity.Member;
 import com.api.onboardingkit.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -19,16 +20,16 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public CustomResponse<Member> getMyProfile() {
+    public ResponseEntity<CustomResponse<Member>> getMyProfile() {
         Member member = memberService.getCurrentMember()
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_FROM_ACCESS_TOKEN));
-        return CustomResponse.success(member, SuccessStatus.GET_MEMBER_OK);
+        return ResponseEntity.ok(CustomResponse.success(member, SuccessStatus.GET_MEMBER_OK));
     }
 
     @PatchMapping
-    public CustomResponse<?> updateMyProfile(@Valid @RequestBody MemberRequestDto requestDto){
+    public ResponseEntity<CustomResponse<?>> updateMyProfile(@Valid @RequestBody MemberRequestDto requestDto){
         memberService.saveOrUpdate(requestDto);
-        return CustomResponse.success(SuccessStatus.UPDATE_MEMBER_OK);
+        return ResponseEntity.ok(CustomResponse.success(SuccessStatus.UPDATE_MEMBER_OK));
     }
 
 }

--- a/src/main/java/com/api/onboardingkit/member/entity/Member.java
+++ b/src/main/java/com/api/onboardingkit/member/entity/Member.java
@@ -22,6 +22,9 @@ public class Member {
     private String detailRole;  // 상세 직무
     private int experience; // 연차
 
+    @Setter
+    private String refreshToken;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)") // ENUM 대신 문자열 저장
     private SocialType socialType; // GOOGLE, KAKAO, APPLE

--- a/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
@@ -8,6 +8,7 @@ import com.api.onboardingkit.oauth.dto.TokenReissueRequestDto;
 import com.api.onboardingkit.oauth.dto.TokenResponseDto;
 import com.api.onboardingkit.oauth.service.OAuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,14 +22,14 @@ public class OAuthController {
     private final OAuthService oAuthService;
 
     @PostMapping("/login")
-    public CustomResponse<OAuthResponseDto> OAuth2Login(@RequestBody OAuthRequestDto requestDto) {
+    public ResponseEntity<CustomResponse<OAuthResponseDto>> OAuth2Login(@RequestBody OAuthRequestDto requestDto) {
         OAuthResponseDto responseDto = oAuthService.authenticate(requestDto);
-        return CustomResponse.success(responseDto, SuccessStatus.OAUTH_AUTHENTICATION);
+        return ResponseEntity.ok(CustomResponse.success(responseDto, SuccessStatus.OAUTH_AUTHENTICATION));
     }
 
     @PostMapping("/reissue")
-    public CustomResponse<TokenResponseDto> reissue(@RequestBody TokenReissueRequestDto requestDto) {
+    public ResponseEntity<CustomResponse<TokenResponseDto>> reissue(@RequestBody TokenReissueRequestDto requestDto) {
         TokenResponseDto response = oAuthService.reissueToken(requestDto);
-        return CustomResponse.success(response, SuccessStatus.TOKEN_REISSUE_OK);
+        return ResponseEntity.ok(CustomResponse.success(response, SuccessStatus.TOKEN_REISSUE_OK));
     }
 }

--- a/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
+++ b/src/main/java/com/api/onboardingkit/oauth/controller/OAuthController.java
@@ -1,8 +1,11 @@
 package com.api.onboardingkit.oauth.controller;
 
 import com.api.onboardingkit.config.response.dto.CustomResponse;
+import com.api.onboardingkit.config.response.dto.SuccessStatus;
 import com.api.onboardingkit.oauth.dto.OAuthRequestDto;
 import com.api.onboardingkit.oauth.dto.OAuthResponseDto;
+import com.api.onboardingkit.oauth.dto.TokenReissueRequestDto;
+import com.api.onboardingkit.oauth.dto.TokenResponseDto;
 import com.api.onboardingkit.oauth.service.OAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +22,13 @@ public class OAuthController {
 
     @PostMapping("/login")
     public CustomResponse<OAuthResponseDto> OAuth2Login(@RequestBody OAuthRequestDto requestDto) {
-        return oAuthService.authenticate(requestDto);
+        OAuthResponseDto responseDto = oAuthService.authenticate(requestDto);
+        return CustomResponse.success(responseDto, SuccessStatus.OAUTH_AUTHENTICATION);
+    }
+
+    @PostMapping("/reissue")
+    public CustomResponse<TokenResponseDto> reissue(@RequestBody TokenReissueRequestDto requestDto) {
+        TokenResponseDto response = oAuthService.reissueToken(requestDto);
+        return CustomResponse.success(response, SuccessStatus.TOKEN_REISSUE_OK);
     }
 }

--- a/src/main/java/com/api/onboardingkit/oauth/dto/TokenReissueRequestDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/TokenReissueRequestDto.java
@@ -1,0 +1,8 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/api/onboardingkit/oauth/dto/TokenResponseDto.java
+++ b/src/main/java/com/api/onboardingkit/oauth/dto/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.api.onboardingkit.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
## :hash: 연관된 이슈
closed #3 

## :memo: 작업 내용
토큰 구조
- sub에 memberId 저장

재발급 단계
1. 토큰을 파싱해서 memberId를 추출
2. 해당 멤버 객체를 조회하고 그 멤버의 refresh와 request 내용을 비교
3. 두 내용이 같다면 토큰을 재발급

### 스크린샷 (선택)

## :speech_balloon: 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
